### PR TITLE
fix(title-numbering): no enclosing backticks in code cell

### DIFF
--- a/title-numbering/index.qmd
+++ b/title-numbering/index.qmd
@@ -9,7 +9,7 @@ number-sections: true
 
 The first title will be prepended with the number 1!
 
-{r} 1 + 1
+`{r} 1 + 1`
 
 # Second title
 

--- a/title-numbering/index.qmd
+++ b/title-numbering/index.qmd
@@ -9,7 +9,9 @@ number-sections: true
 
 The first title will be prepended with the number 1!
 
-`{r} 1 + 1`
+```{r}
+1 + 1
+```
 
 # Second title
 


### PR DESCRIPTION
This PRs fixes what seems to be an inline R expression with the 1.4 unified/cross-language syntax.

Edit: actually it was a regular code cell from other example in this repository.